### PR TITLE
Mismatch info

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -24,7 +24,12 @@ jobs:
     - uses: actions/checkout@v3
       with:
         ref: ${{ inputs.ref || github.ref }}
+
     - name: Build
       run: cargo build --verbose
+
+    - name: Check formatting
+      run: cargo fmt --check
+
     - name: Run tests
       run: cargo test --verbose

--- a/src/brainfuck.rs
+++ b/src/brainfuck.rs
@@ -37,7 +37,7 @@ pub enum Commands {
 
 #[derive(Debug, PartialEq)]
 pub enum BrainfuckError {
-    MismatchedOpen,
+    MismatchedOpen { line: u8, col: u8 },
     MismatchedClose { line: u8, col: u8 },
     DataPointerNegative,
     DataPointerOverflow,
@@ -48,8 +48,8 @@ pub enum BrainfuckError {
 impl BrainfuckError {
     fn to_error(&self) -> Error {
         match self {
-            MismatchedOpen => Error {
-                msg: String::from("Mismatched '['."),
+            MismatchedOpen { line, col } => Error {
+                msg: format!("Mismatched '[' at {}:{}.", line, col),
                 exit_code: 1,
             },
             MismatchedClose { line, col } => Error {

--- a/src/brainfuck.rs
+++ b/src/brainfuck.rs
@@ -31,14 +31,14 @@ pub enum Commands {
     DecData,
     Output,
     Input,
-    StartBlock { next_instr: Option<usize> },
-    EndBlock { next_instr: Option<usize> },
+    StartBlock { next_instr: usize },
+    EndBlock { next_instr: usize },
 }
 
 #[derive(Debug, PartialEq)]
 pub enum BrainfuckError {
     MismatchedOpen,
-    MismatchedClose,
+    MismatchedClose { line: u8, col: u8 },
     DataPointerNegative,
     DataPointerOverflow,
     DataOverflow,
@@ -52,8 +52,8 @@ impl BrainfuckError {
                 msg: String::from("Mismatched '['."),
                 exit_code: 1,
             },
-            MismatchedClose => Error {
-                msg: String::from("Mismatched ']'."),
+            MismatchedClose { line, col } => Error {
+                msg: format!("Mismatched ']' at {}:{}.", line, col),
                 exit_code: 2,
             },
             DataPointerNegative => Error {

--- a/src/brainfuck/machine.rs
+++ b/src/brainfuck/machine.rs
@@ -35,7 +35,7 @@ impl Machine {
     }
 
     pub(crate) fn execute(&mut self) -> Result<(), BrainfuckError> {
-        while (self.instr_pointer as usize) < self.commands.len() {
+        while (self.instr_pointer) < self.commands.len() {
             let last_command_result = match self.commands[self.instr_pointer] {
                 Commands::IncDataPointer => self.inc_data_pointer(),
                 Commands::DecDataPointer => self.dec_data_pointer(),
@@ -43,8 +43,8 @@ impl Machine {
                 Commands::DecData => self.dec_data(),
                 Commands::Output => self.output(),
                 Commands::Input => self.input(),
-                Commands::StartBlock { next_instr } => self.jmp_z(next_instr.unwrap()),
-                Commands::EndBlock { next_instr } => self.jmp_nz(next_instr.unwrap()),
+                Commands::StartBlock { next_instr } => self.jmp_z(next_instr),
+                Commands::EndBlock { next_instr } => self.jmp_nz(next_instr),
             };
 
             if last_command_result.is_err() {

--- a/src/brainfuck/machine/machine_test.rs
+++ b/src/brainfuck/machine/machine_test.rs
@@ -40,16 +40,12 @@ fn block_test() {
     let commands = vec![
         IncData,
         IncData,
-        StartBlock {
-            next_instr: Some(7),
-        },
+        StartBlock { next_instr: 7 },
         DecData,
         IncDataPointer,
         IncData,
         DecDataPointer,
-        EndBlock {
-            next_instr: Some(2),
-        },
+        EndBlock { next_instr: 2 },
     ];
     let mut machine = Machine::create(commands);
     let result = machine.execute();
@@ -67,21 +63,37 @@ fn data_pointer_negative() {
 
 #[test]
 fn data_pointer_overflow() {
-    let commands = vec![IncData, StartBlock {next_instr: Some(3)}, IncDataPointer, IncData, EndBlock {next_instr: Some(1)}];
+    let commands = vec![
+        IncData,
+        StartBlock { next_instr: 3 },
+        IncDataPointer,
+        IncData,
+        EndBlock { next_instr: 1 },
+    ];
     let result = Machine::create(commands).execute();
     assert_eq!(result, Err(DataPointerOverflow))
 }
 
 #[test]
 fn positive_data_overflow() {
-    let commands = vec![IncData, StartBlock {next_instr: Some(3)}, IncData, EndBlock {next_instr: Some(1)}];
+    let commands = vec![
+        IncData,
+        StartBlock { next_instr: 3 },
+        IncData,
+        EndBlock { next_instr: 1 },
+    ];
     let result = Machine::create(commands).execute();
     assert_eq!(result, Err(DataOverflow))
 }
 
 #[test]
 fn negative_data_overflow() {
-    let commands = vec![DecData, StartBlock {next_instr: Some(3)}, DecData, EndBlock {next_instr: Some(1)}];
+    let commands = vec![
+        DecData,
+        StartBlock { next_instr: 3 },
+        DecData,
+        EndBlock { next_instr: 1 },
+    ];
     let result = Machine::create(commands).execute();
     assert_eq!(result, Err(DataOverflow))
 }

--- a/src/brainfuck/parser/parser_test.rs
+++ b/src/brainfuck/parser/parser_test.rs
@@ -32,7 +32,7 @@ fn parse_test() {
         IncDataPointer,
         IncData,
         DecDataPointer,
-        EndBlock { next_instr: 2 },
+        EndBlock { next_instr: 3 },
     ];
     assert_eq!(expected.len(), byte_code.len());
     for i in 0..(expected.len() - 1) {
@@ -43,7 +43,7 @@ fn parse_test() {
 #[test]
 fn mismatched_open() {
     let result = parse(String::from("[[]"));
-    assert_eq!(result, Err(MismatchedOpen))
+    assert_eq!(result, Err(MismatchedOpen { line: 1, col: 1 }))
 }
 
 #[test]

--- a/src/brainfuck/parser/parser_test.rs
+++ b/src/brainfuck/parser/parser_test.rs
@@ -12,13 +12,13 @@
  *     GNU General Public License for more details.
  */
 
-use BrainfuckError::MismatchedOpen;
+use crate::brainfuck::parser::parse;
 use crate::brainfuck::BrainfuckError;
 use crate::brainfuck::BrainfuckError::MismatchedClose;
-use crate::brainfuck::parser::parse;
 use crate::brainfuck::Commands::{
     DecData, DecDataPointer, EndBlock, IncData, IncDataPointer, StartBlock,
 };
+use BrainfuckError::MismatchedOpen;
 
 #[test]
 fn parse_test() {
@@ -27,16 +27,12 @@ fn parse_test() {
     let expected = vec![
         IncData,
         IncData,
-        StartBlock {
-            next_instr: Some(7),
-        },
+        StartBlock { next_instr: 7 },
         DecData,
         IncDataPointer,
         IncData,
         DecDataPointer,
-        EndBlock {
-            next_instr: Some(2),
-        },
+        EndBlock { next_instr: 2 },
     ];
     assert_eq!(expected.len(), byte_code.len());
     for i in 0..(expected.len() - 1) {
@@ -53,5 +49,5 @@ fn mismatched_open() {
 #[test]
 fn mismatched_close() {
     let result = parse(String::from("[]]"));
-    assert_eq!(result, Err(MismatchedClose))
+    assert_eq!(result, Err(MismatchedClose { line: 1, col: 3 }))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,10 +30,11 @@ fn main() {
         }
         Ok(_) => {}
     }
+    println!();
 }
 
 fn exit(error: Error) {
-    print!("{}", error.msg);
+    println!("{}", error.msg);
     std::process::exit(error.exit_code);
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,9 +12,9 @@
  *     GNU General Public License for more details.
  */
 
-use Commands::Brainfuck;
 use crate::interpreter::Error;
 use clap::{Parser, Subcommand};
+use Commands::Brainfuck;
 
 mod brainfuck;
 mod interpreter;
@@ -22,9 +22,7 @@ mod interpreter;
 fn main() {
     let args = Cli::parse();
     let result = match args.command {
-        Brainfuck { source } => {
-            brainfuck::execute(source)
-        }
+        Brainfuck { source } => brainfuck::execute(source),
     };
     match result {
         Err(error) => {
@@ -44,13 +42,11 @@ fn exit(error: Error) {
 #[command(about = "A collection of esoteric languages interpreters.", long_about = None)]
 struct Cli {
     #[command(subcommand)]
-    command: Commands
+    command: Commands,
 }
 
 #[derive(Debug, Subcommand)]
 enum Commands {
     #[command(arg_required_else_help = true)]
-    Brainfuck {
-        source: String
-    },
+    Brainfuck { source: String },
 }


### PR DESCRIPTION
Fixes #2 

Fixes a bug where the end block would return to the start block instruction, instead of the instruction after it.
Removed Option from the Start/EndBlock instructions.